### PR TITLE
Adding backend tests

### DIFF
--- a/tests/backend/specs/contest.spec.ts
+++ b/tests/backend/specs/contest.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test";
+import { getContestType, getRandomContestType } from "../src/utils/pokeapi";
+import { expectedContestTypeStructure } from "../src/utils/testData";
+
+test.describe("Contest Type API Tests", () => {
+  test("Should return valid contest type data for a random contest type @api @contest", async ({
+    request,
+  }) => {
+    const contestType = getRandomContestType();
+    const response = await getContestType(request, contestType);
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+
+    // Check basic properties
+    for (const prop of expectedContestTypeStructure.basic) {
+      expect(data).toHaveProperty(prop);
+    }
+
+    // Check berry flavor structure
+    expect(data.berry_flavor).toHaveProperty("name");
+    expect(data.berry_flavor).toHaveProperty("url");
+    expect(typeof data.berry_flavor.name).toBe(
+      expectedContestTypeStructure.berry_flavor.name
+    );
+    expect(typeof data.berry_flavor.url).toBe(
+      expectedContestTypeStructure.berry_flavor.url
+    );
+    expect(data.berry_flavor.url).toMatch(
+      /^https:\/\/pokeapi\.co\/api\/v2\/berry-flavor\/\d+\/$/
+    );
+
+    // Check names array structure
+    expect(Array.isArray(data.names)).toBe(true);
+    if (data.names.length > 0) {
+      const expectedNameStructure = expectedContestTypeStructure.names[0];
+      for (const nameEntry of data.names) {
+        // Check basic properties
+        expect(nameEntry).toHaveProperty("name");
+        expect(nameEntry).toHaveProperty("color");
+        expect(nameEntry).toHaveProperty("language");
+        expect(typeof nameEntry.name).toBe(expectedNameStructure.name);
+        expect(typeof nameEntry.color).toBe(expectedNameStructure.color);
+
+        // Check language object structure
+        expect(nameEntry.language).toHaveProperty("name");
+        expect(nameEntry.language).toHaveProperty("url");
+        expect(typeof nameEntry.language.name).toBe(
+          expectedNameStructure.language.name
+        );
+        expect(typeof nameEntry.language.url).toBe(
+          expectedNameStructure.language.url
+        );
+      }
+    }
+
+    console.log(
+      "Successfully validated the structure of the contest type data"
+    );
+  });
+});

--- a/tests/backend/specs/locations.spec.ts
+++ b/tests/backend/specs/locations.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+import { getLocation, getRandomLocation } from "../src/utils/pokeapi";
+import { expectedLocationStructure } from "../src/utils/testData";
+
+test.describe("/location Endpoint Scenarios", () => {
+  test("Should return a valid location for a given ID or name @api @location", async ({
+    request,
+  }) => {
+    const locationName = getRandomLocation();
+    const response = await getLocation(request, locationName);
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+
+    // Validate basic properties
+    for (const prop of expectedLocationStructure.basic) {
+      expect(data).toHaveProperty(prop);
+    }
+
+    // Validate region
+    expect(data).toHaveProperty(
+      "region",
+      expect.objectContaining({
+        name: expect.any(String),
+        url: expect.any(String),
+      })
+    );
+
+    // Validate game indices
+    expect(data).toHaveProperty("game_indices");
+    expect(data.game_indices.length).toBeGreaterThan(0);
+
+    // Validate areas
+    expect(data).toHaveProperty("areas");
+    expect(data.areas.length).toBeGreaterThan(0);
+
+    console.log("Successfully validated the structure of the location data");
+  });
+});

--- a/tests/backend/specs/moves.spec.ts
+++ b/tests/backend/specs/moves.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+import { expectedMoveStructure } from "../src/utils/testData";
+import { getRandomMove, getMove } from "../src/utils/pokeapi";
+
+test.describe("/moves Endpoint Scenarios", () => {
+  test("Should return valid structure for a known move @api @moves", async ({
+    request,
+  }) => {
+    const moveName = getRandomMove();
+    const response = await getMove(request, moveName);
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+
+    // Validate basic properties
+    for (const prop of expectedMoveStructure.basic) {
+      expect(data).toHaveProperty(prop);
+    }
+
+    // Validate nested properties
+    for (const [key, nestedProps] of Object.entries(
+      expectedMoveStructure.nested
+    )) {
+      expect(data).toHaveProperty(key);
+      for (const nestedProp of nestedProps) {
+        expect(data[key]).toHaveProperty(nestedProp);
+      }
+    }
+
+    // Optional properties can be present or null; if present, validate their structure
+    for (const optionalProp of expectedMoveStructure.optional) {
+      if (data[optionalProp] !== undefined && data[optionalProp] !== null) {
+        expect(data).toHaveProperty(optionalProp);
+      }
+    }
+    console.log("Successfully validated the structure of the move data");
+  });
+});

--- a/tests/backend/specs/pokemon.spec.ts
+++ b/tests/backend/specs/pokemon.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from "@playwright/test";
+import { expectedStructure } from "../src/utils/testData";
+import { getPokemon, getRandomPokemon } from "../src/utils/pokeapi";
+
+test.describe("/pokemon Endpoint Scenarios", () => {
+  test("Should return valid structure for a known Pokémon @api @pokemon", async ({
+    request,
+  }) => {
+    // Get a random Pokémon name from the list of known Pokémon
+    const pokemonName = getRandomPokemon();
+    const response = await getPokemon(request, pokemonName);
+
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+
+    // Check basic properties
+    for (const prop of expectedStructure.basic) {
+      expect(data).toHaveProperty(prop);
+    }
+
+    // Check types structure
+    expect(Array.isArray(data.types)).toBe(true);
+    if (data.types.length > 0) {
+      for (const typeEntry of data.types) {
+        for (const prop of expectedStructure.types.properties) {
+          expect(typeEntry).toHaveProperty(prop);
+        }
+        for (const nestedProp of expectedStructure.types.nested.type) {
+          expect(typeEntry.type).toHaveProperty(nestedProp);
+          expect(typeof typeEntry.type[nestedProp]).toBe("string");
+        }
+      }
+    }
+
+    // Check abilities structure
+    expect(Array.isArray(data.abilities)).toBe(true);
+    if (data.abilities.length > 0) {
+      for (const abilityEntry of data.abilities) {
+        for (const prop of expectedStructure.abilities.properties) {
+          expect(abilityEntry).toHaveProperty(prop);
+        }
+        for (const nestedProp of expectedStructure.abilities.nested.ability) {
+          expect(abilityEntry.ability).toHaveProperty(nestedProp);
+          expect(typeof abilityEntry.ability[nestedProp]).toBe("string");
+        }
+      }
+    }
+
+    // Check moves structure
+    expect(Array.isArray(data.moves)).toBe(true);
+    if (data.moves.length > 0) {
+      for (const moveEntry of data.moves) {
+        for (const prop of expectedStructure.moves.properties) {
+          expect(moveEntry).toHaveProperty(prop);
+        }
+        for (const nestedProp of expectedStructure.moves.nested.move) {
+          expect(moveEntry.move).toHaveProperty(nestedProp);
+          expect(typeof moveEntry.move[nestedProp]).toBe("string");
+        }
+      }
+    }
+
+    // Check sprite URLs
+    for (const spriteProp of expectedStructure.sprites.properties) {
+      if (data.sprites[spriteProp]) {
+        expect(data.sprites[spriteProp]).toMatch(
+          expectedStructure.sprites.urlPattern
+        );
+      }
+    }
+    console.log("Successfully validated the structure of the Pokémon data");
+  });
+
+  test("Should return a 404 error for a non-existent Pokémon @api @pokemon", async ({
+    request,
+  }) => {
+    const nonExistentPokemon = "non-existent-pokemon";
+    const response = await getPokemon(request, nonExistentPokemon);
+    expect(response.status()).toBe(404);
+    console.log(
+      "Successfully validated the 404 error for a non-existent Pokémon"
+    );
+  });
+});

--- a/tests/backend/src/utils/config.ts
+++ b/tests/backend/src/utils/config.ts
@@ -1,0 +1,3 @@
+export const config = {
+  baseURLPokeAPI: "https://pokeapi.co/api/v2",
+};

--- a/tests/backend/src/utils/pokeapi.ts
+++ b/tests/backend/src/utils/pokeapi.ts
@@ -1,0 +1,107 @@
+import { APIRequestContext } from "@playwright/test";
+import { config } from "./config";
+import {
+  knownContestTypes,
+  knownLocations,
+  knownMoves,
+  knownPokemon,
+} from "./testData";
+
+const BASE_URL = config.baseURLPokeAPI;
+
+/**
+ * Utility to select a random element from an array
+ * @param list - The array to pick from
+ * @returns A random element from the array
+ */
+function getRandomItem<T>(list: T[]): T {
+  const index = Math.floor(Math.random() * list.length);
+  return list[index];
+}
+
+/**
+ * Get a random Pokémon name from the list of known Pokémon
+ * @returns A random Pokémon name
+ */
+export function getRandomPokemon(): string {
+  return getRandomItem(knownPokemon);
+}
+
+/**
+ * Get a random move name from the list of known moves
+ * @returns A random move name
+ */
+export function getRandomMove(): string {
+  return getRandomItem(knownMoves);
+}
+
+/**
+ * Get a random contest type from the list of known contest types
+ * @returns A random contest type
+ */
+export function getRandomContestType(): string {
+  return getRandomItem(knownContestTypes);
+}
+
+/**
+ * Get a random item from the list of known items
+ * @returns A random item
+ */
+export function getRandomLocation(): string {
+  return getRandomItem(knownLocations);
+}
+
+/**
+ * Get a Pokémon by name
+ * @param request - The API request context
+ * @param pokemonName - The name of the Pokémon
+ * @returns The response object
+ */
+export async function getPokemon(
+  request: APIRequestContext,
+  pokemonName: string
+) {
+  const response = await request.get(`${BASE_URL}/pokemon/${pokemonName}`);
+  return response;
+}
+
+/**
+ * Get a move by name
+ * @param request - The API request context
+ * @param moveName - The name of the move
+ * @returns The response object
+ */
+export async function getMove(request: APIRequestContext, moveName: string) {
+  const response = await request.get(`${BASE_URL}/move/${moveName}`);
+  return response;
+}
+
+/**
+ * Get a contest type by name
+ * @param request - The API request context
+ * @param contestTypeName - The name of the contest type
+ * @returns The response object
+ */
+export async function getContestType(
+  request: APIRequestContext,
+  contestTypeName: string
+) {
+  const response = await request.get(
+    `${BASE_URL}/contest-type/${contestTypeName}`
+  );
+  return response;
+}
+
+/**
+ * Get a location by name
+ * @param request - The API request context
+ * @param locationName - The name of the location
+ * @returns The response object
+ */
+export async function getLocation(
+  request: APIRequestContext,
+  locationName: string
+) {
+  const response = await request.get(`${BASE_URL}/location/${locationName}`);
+  return response;
+}

--- a/tests/backend/src/utils/testData.ts
+++ b/tests/backend/src/utils/testData.ts
@@ -1,0 +1,208 @@
+/**
+ * List of known Pokémon names
+ * @type {Array}
+ */
+export const knownPokemon = [
+  "pikachu",
+  "bulbasaur",
+  "charizard",
+  "mewtwo",
+  "snorlax",
+];
+
+/**
+ * List of known moves
+ * @type {Array}
+ */
+export const knownMoves = [
+  "pound",
+  "tackle",
+  "thunder-punch",
+  "earthquake",
+  "ice-beam",
+];
+
+/**
+ * List of known locations
+ * @type {Array}
+ */
+export const knownLocations = ["canalave-city", "sinnoh-region"];
+
+/**
+ * List of known contest types
+ * @type {Array}
+ */
+export const knownContestTypes = ["cool", "beauty", "cute", "clever", "tough"];
+
+/**
+ * Expected response structure for move data
+ * @type {Object}
+ * @property {Array} basic - Basic properties expected in the response
+ * @property {Object} nested - Nested properties expected in the response
+ * @property {Array} optional - Optional properties expected in the response
+ */
+export const expectedMoveStructure = {
+  basic: [
+    "id",
+    "name",
+    "accuracy",
+    "effect_chance",
+    "pp",
+    "priority",
+    "power",
+    "type",
+    "damage_class",
+    "generation",
+  ],
+  nested: {
+    type: ["name", "url"],
+    damage_class: ["name", "url"],
+    generation: ["name", "url"],
+  },
+  optional: [
+    "contest_combos",
+    "contest_type",
+    "contest_effect",
+    "effect_entries",
+    "effect_changes",
+    "flavor_text_entries",
+    "learned_by_pokemon",
+    "meta",
+    "names",
+    "past_values",
+    "stat_changes",
+    "super_contest_effect",
+    "target",
+    "machines",
+  ],
+};
+
+/**
+ * Expected response structure for contest type data
+ * @type {Object}
+ * @property {Array} basic - Basic properties expected in the response
+ * @property {Object} berry_flavor - Expected structure for berry flavor
+ * @property {Array} names - Expected structure for names
+ */
+export const expectedContestTypeStructure = {
+  basic: ["id", "name", "berry_flavor", "names"],
+  berry_flavor: {
+    name: "string",
+    url: "string",
+  },
+  names: [
+    {
+      name: "string",
+      color: "string",
+      language: {
+        name: "string",
+        url: "string",
+      },
+    },
+  ],
+};
+
+/**
+ * Expected response structure for item data
+ * @type {Object}
+ * @property {Array} basic - Basic properties expected in the response
+ * @property {Object} nested - Nested properties expected in the response
+ * @property {Array} optional - Optional properties expected in the response
+ */
+export const expectedItemStructure = {
+  basic: [
+    "id",
+    "name",
+    "cost",
+    "fling_power",
+    "fling_effect",
+    "attributes",
+    "category",
+    "effect_entries",
+    "flavor_text_entries",
+    "game_indices",
+    "names",
+    "sprites",
+    "held_by_pokemon",
+    "baby_trigger_for",
+    "machines",
+  ],
+  nested: {
+    fling_effect: ["name", "url"],
+    category: ["name", "url"],
+    effect_entries: ["effect", "short_effect", "language"],
+    flavor_text_entries: ["flavor_text", "language"],
+    game_indices: ["game_index", "generation"],
+    names: ["name", "language"],
+    sprites: ["default"],
+    held_by_pokemon: ["pokemon", "url"],
+    baby_trigger_for: ["url"],
+    machines: ["machine", "version_group"],
+  },
+  optional: [
+    "effect_entries",
+    "flavor_text_entries",
+    "game_indices",
+    "names",
+    "sprites",
+    "held_by_pokemon",
+    "baby_trigger_for",
+    "machines",
+  ],
+};
+
+/**
+ * Expected response structure for location data
+ * @type {Object}
+ * @property {Array} basic - Basic properties expected in the response
+ * @property {Object} region - Expected structure for region
+ * @property {Array} game_indices - Expected structure for game indices
+ * @property {Array} areas - Expected structure for areas
+ */
+export const expectedLocationStructure = {
+  basic: ["id", "name", "region", "game_indices", "areas"],
+  region: {
+    name: "string",
+    url: "string",
+  },
+  game_indices: ["game_index", "generation"],
+  areas: ["name", "url"],
+};
+
+/**
+ * Expected response structure for Pokémon data
+ * @type {Object}
+ * @property {Array} basic - Basic properties expected in the response
+ * @property {Object} types - Expected structure for types
+ * @property {Object} abilities - Expected structure for abilities
+ * @property {Object} moves - Expected structure for moves
+ * @property {Object} sprites - Expected structure for sprites
+ */
+export const expectedStructure = {
+  basic: [
+    "id",
+    "name",
+    "height",
+    "weight",
+    "types",
+    "abilities",
+    "moves",
+    "sprites",
+  ],
+  types: {
+    properties: ["type"],
+    nested: { type: ["name"] },
+  },
+  abilities: {
+    properties: ["ability"],
+    nested: { ability: ["name"] },
+  },
+  moves: {
+    properties: ["move"],
+    nested: { move: ["name"] },
+  },
+  sprites: {
+    properties: ["front_default", "back_default"],
+    urlPattern: /^https:\/\/.*\.png$/,
+  },
+};


### PR DESCRIPTION
test: implement PokeAPI test suite

- Add API test specifications for core endpoints:
  - Pokémon data validation and error handling
  - Contest type structure verification
  - Location data validation
  - Move data structure testing
- Implement test utilities:
  - API request helpers
  - Random data generators
  - Response structure validators
- Add test data structures:
  - Expected response schemas
  - Known test data sets
  - Configuration constants

This commit establishes a comprehensive API test suite for the PokeAPI,
ensuring data integrity and proper error handling across endpoints.