### PR TITLE
Adding reporting for remote github actions run and also adding it to …

### DIFF
--- a/.github/workflows/playwright-tests-and-report.yml
+++ b/.github/workflows/playwright-tests-and-report.yml
@@ -60,5 +60,5 @@ jobs:
       - name: Add summary to GitHub Actions
         if: always()
         run: |
-          echo "## Playwright Tests Completed" >> $GITHUB_STEP_SUMMARY
-          echo "View the full report on [GitHub Pages](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/)" >> $GITHUB_STEP_SUMMARY
+          echo "## ✅ Playwright Tests Completed" >> $GITHUB_STEP_SUMMARY
+          echo "🔗 [View the report on GitHub Pages](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/playwright-tests-and-report.yml
+++ b/.github/workflows/playwright-tests-and-report.yml
@@ -7,16 +7,10 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: write # Needed for GitHub Pages deployment
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Node.js
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/playwright-tests-and-report.yml
+++ b/.github/workflows/playwright-tests-and-report.yml
@@ -6,8 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/playwright-tests-and-report.yml
+++ b/.github/workflows/playwright-tests-and-report.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: write # Needed for GitHub Pages deployment
+  contents: write
 
 jobs:
   test:
@@ -60,5 +60,5 @@ jobs:
       - name: Add summary to GitHub Actions
         if: always()
         run: |
-          echo "##Playwright Tests Completed" >> $GITHUB_STEP_SUMMARY
+          echo "## Playwright Tests Completed" >> $GITHUB_STEP_SUMMARY
           echo "[View the report on GitHub Pages](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/playwright-tests-and-report.yml
+++ b/.github/workflows/playwright-tests-and-report.yml
@@ -60,5 +60,5 @@ jobs:
       - name: Add summary to GitHub Actions
         if: always()
         run: |
-          echo "## Playwright Tests Completed" >> $GITHUB_STEP_SUMMARY
+          echo "Playwright Tests Completed" >> $GITHUB_STEP_SUMMARY
           echo "[View the report on GitHub Pages](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/playwright-tests-and-report.yml
+++ b/.github/workflows/playwright-tests-and-report.yml
@@ -60,5 +60,5 @@ jobs:
       - name: Add summary to GitHub Actions
         if: always()
         run: |
-          echo "## ✅ Playwright Tests Completed" >> $GITHUB_STEP_SUMMARY
-          echo "🔗 [View the report on GitHub Pages](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/)" >> $GITHUB_STEP_SUMMARY
+          echo "##Playwright Tests Completed" >> $GITHUB_STEP_SUMMARY
+          echo "[View the report on GitHub Pages](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,25 @@ jobs:
           CI: true
           SHOPIFY_PASSWORD: ${{ secrets.SHOPIFY_PASSWORD }}
 
-      - name: Upload test results
+      - name: Upload test results as artifact
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+
+      - name: Deploy HTML report to GitHub Pages
+        if: always()
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./playwright-report
+          publish_branch: gh-pages
+          force_orphan: true
+
+      - name: Add summary to GitHub Actions
+        if: always()
+        run: |
+          echo "## Playwright Tests Completed" >> $GITHUB_STEP_SUMMARY
+          echo "View the full report on [GitHub Pages](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/)" >> $GITHUB_STEP_SUMMARY

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,13 +6,12 @@ dotenv.config();
 export default defineConfig({
   testDir: "./tests",
   fullyParallel: true,
-  // 1 minute timeout
   timeout: 60000,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 2 : undefined,
   reporter: [
-    ["html"],
+    ["html", { outputFolder: "playwright-report" }],
     ["junit", { outputFile: "test-results/e2e-junit-results.xml" }],
     ["list"],
   ],


### PR DESCRIPTION
feat: enhance test reporting in GitHub Actions

- Add GitHub Pages deployment for Playwright reports
  - Configure gh-pages branch for report hosting
  - Set up automatic report publishing
- Add GitHub Actions summary integration
  - Include report link in workflow summary
  - Improve test result visibility
- Update artifact upload configuration
  - Use latest actions-upload-artifact version
  - Maintain 30-day retention policy

This commit improves test result accessibility by publishing reports
to GitHub Pages and integrating them into the GitHub Actions interface.